### PR TITLE
Fixed the link to the CNCF COC

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,8 +1,8 @@
 ## Community Code of Conduct v1.0
 
 This is Code of Conduct is based on the [CNCF Code of
-Conduct](https://github.com/cncf/foundation/edit/master/code-of-conduct.md).
-See the referred document for translated versions into different languages. 
+Conduct](https://github.com/cncf/foundation/blob/master/code-of-conduct.md).
+See the referred document for translated versions into different languages.
 
 ### Contributor Code of Conduct
 


### PR DESCRIPTION
Noticed that this link in the CODE_OF_CONDUCT.md had an `edit` link instead of `blob` link.